### PR TITLE
rescue Permission Denied

### DIFF
--- a/lib/bootsnap/load_path_cache/store.rb
+++ b/lib/bootsnap/load_path_cache/store.rb
@@ -75,7 +75,11 @@ module Bootsnap
         # `encoding:` looks redundant wrt `binwrite`, but necessary on windows
         # because binary is part of mode.
         File.binwrite(tmp, MessagePack.dump(@data), mode: exclusive_write, encoding: Encoding::BINARY)
-        FileUtils.mv(tmp, @store_path)
+        begin
+          FileUtils.mv(tmp, @store_path)
+        rescue Errno::EACCESS
+          # make some code
+        end
       rescue Errno::EEXIST
         retry
       end


### PR DESCRIPTION
* Windows7 x64
* rbenv-win for powershell (https://qiita.com/nak1114/items/0cbf4797d95422b04569)
* ruby 2.3.3-x64
* rails 5.2.0
* I have an admin rights.

Maybe, @store_path or tmp sometimes does not exist.
If @store_path is the cause of an error, make some directory.
If tmp is the cause of an error, don't exists file.
Or caches can not be erased, caches can not be move.
etc...

I don't know why the cause of an error.
This error is not reproducible.
I'm very embarrassed, I propose this pull request fixed an error.

Thank you.